### PR TITLE
Increasing network attach timeout in soracom-connectivity-diagnostics

### DIFF
--- a/examples/soracom/soracom-connectivity-diagnostics/soracom-connectivity-diagnostics.ino
+++ b/examples/soracom/soracom-connectivity-diagnostics/soracom-connectivity-diagnostics.ino
@@ -207,7 +207,7 @@ void setup(void) {
   const auto start = millis();
   do {
     ABORT_IF_FAILED(WioCellular.getEpsNetworkRegistrationState(&state));
-  } while (state != 1 && state != 5 && millis() - start < 60000);
+  } while (state != 1 && state != 5 && millis() - start < 120000);
   CONSOLE.println(state == 1 || state == 5 ? "[OK]" : "[FAILED]");
   if (state != 1 && state != 5) {
     CONSOLE.println("Failed to connect cellular network.");


### PR DESCRIPTION
In this pull request, I have updated timeout value of network attachment from 60 seconds to 120 seconds.

Background:
When full network scan occured, it may takes 60+ seconds until network attach, so it was ocasionally failing.