### PR TITLE
SORACOM Beam経由でMQTT接続するサンプルを追加

### DIFF
--- a/examples/cellular/cellular-mqtt-pubsubclient/cellular-mqtt-pubsubclient.ino
+++ b/examples/cellular/cellular-mqtt-pubsubclient/cellular-mqtt-pubsubclient.ino
@@ -7,54 +7,52 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Libraries:
 //   http://librarymanager#PubSubClient 2.8.0
+//   http://librarymanager#ArduinoJson 7.0.4
 
 #include <Adafruit_TinyUSB.h>
+#include <csignal>
 #include <WioCellular.h>
 #include <PubSubClient.h>
+#include <ArduinoJson.h>
 
 #define SEARCH_ACCESS_TECHNOLOGY (WioCellularNetwork::SearchAccessTechnology::LTEM)
 #define LTEM_BAND (WioCellularNetwork::NTTDOCOMO_LTEM_BAND)
 static const char APN[] = "soracom.io";
 
+static const char MQTT_BROKER_HOST[] = "test.mosquitto.org";
+static constexpr int MQTT_BROKER_PORT = 1883;
+static constexpr int MQTT_KEEP_ALIVE = 60;
+
+static constexpr int INTERVAL = 1000 * 60 * 5;      // [ms]
 static constexpr int POWER_ON_TIMEOUT = 1000 * 20;  // [ms]
+static constexpr int RECONNECT_WAIT_TIME = 1000;    // [ms]
 
 #define ABORT_IF_FAILED(result) \
   do { \
     if ((result) != WioCellularResult::Ok) abort(); \
   } while (0)
 
-static constexpr int PDP_CONTEXT_ID = 1;
-static constexpr int SOCKET_ID = 0;
-static WioCellularArduinoTcpClient<WioCellularModule> TcpClient{ WioCellular, PDP_CONTEXT_ID };
-
-#define ENDPOINT "beam.soracom.io"
-#define PORT (1883)
-#define SUBSCRIBE_TOPIC "test/cmd"
-
-PubSubClient mqttClient(TcpClient);
-
-void callback(char* topic, byte* payload, unsigned int length) {
-  Serial.print("Message arrived [");
-  Serial.print(topic);                // Display topic
-  Serial.println("] ");
-
-  String payload_str = "";
-  for (unsigned int i = 0; i < length; i++) {  // Parse Message
-    payload_str += (char)payload[i];
+static void abortHandler(int sig) {
+  while (true) {
+    ledOn(LED_BUILTIN);
+    delay(100);
+    ledOff(LED_BUILTIN);
+    delay(100);
   }
-  Serial.println(payload_str);
 }
 
-void connectToMQTTS() {
-  Serial.print("Connecting to MQTTS broker via SORACOM Beam(Proxy): ");
-  mqttClient.setServer(ENDPOINT, PORT);
-  mqttClient.setCallback(callback);
-  mqttClient.connect(SUBSCRIBE_TOPIC);
-  mqttClient.subscribe(SUBSCRIBE_TOPIC, 0);
-  Serial.println("Connected!");
-}
+static constexpr int PDP_CONTEXT_ID = 1;
+
+static JsonDocument JsonDoc;
+static WioCellularArduinoTcpClient<WioCellularModule> TcpClient{ WioCellular, PDP_CONTEXT_ID };
+static PubSubClient MqttClient{ TcpClient };
+static std::string ClientId;
+static std::string SubscribeTopic;
+static std::string PublishTopic;
+static int ReconnectWaitTime = RECONNECT_WAIT_TIME;
 
 void setup(void) {
+  signal(SIGABRT, abortHandler);
   Serial.begin(115200);
   {
     const auto start = millis();
@@ -73,21 +71,100 @@ void setup(void) {
 
   WioNetwork.config.searchAccessTechnology = SEARCH_ACCESS_TECHNOLOGY;
   WioNetwork.config.ltemBand = LTEM_BAND;
+  WioNetwork.config.pdpContextId = PDP_CONTEXT_ID;
   WioNetwork.config.apn = APN;
   WioNetwork.begin();
 
-  connectToMQTTS();
+  std::string imsi;
+  ABORT_IF_FAILED(WioCellular.getIMSI(&imsi));
+  ClientId = imsi;
+  SubscribeTopic = std::string{ "WioCellular/" } + ClientId + "/downstream";
+  PublishTopic = std::string{ "WioCellular/" } + ClientId + "/upstream";
+  Serial.println();
+  Serial.println("Commands:");
+  Serial.printf(" mosquitto_sub -h %s -p %d -t \"%s\"\n", MQTT_BROKER_HOST, MQTT_BROKER_PORT, PublishTopic.c_str());
+  Serial.printf(" mosquitto_pub -h %s -p %d -t \"%s\" -m \"message\"\n", MQTT_BROKER_HOST, MQTT_BROKER_PORT, SubscribeTopic.c_str());
+  Serial.println();
+
+  MqttClient.setServer(MQTT_BROKER_HOST, MQTT_BROKER_PORT);
+  MqttClient.setKeepAlive(MQTT_KEEP_ALIVE);
+  MqttClient.setCallback(MqttClientCallback);
 
   digitalWrite(LED_BUILTIN, LOW);
 }
 
 void loop(void) {
-  if (!mqttClient.connected()) {
-    if (mqttClient.connect(SUBSCRIBE_TOPIC)) {
-      Serial.println("Connected");
-      mqttClient.subscribe(SUBSCRIBE_TOPIC, 0);
-      Serial.println("Subscribed");
+  if (!MqttClient.connected()) {
+    Serial.print("Connecting ");
+    Serial.print(MQTT_BROKER_HOST);
+    Serial.print(":");
+    Serial.println(MQTT_BROKER_PORT);
+    if (!MqttClient.connect(ClientId.c_str())) {
+      Serial.println("ERROR: Failed to connect");
+      WioCellular.doWorkUntil(ReconnectWaitTime);
+
+      ReconnectWaitTime *= 2;
+    } else {
+      ReconnectWaitTime = RECONNECT_WAIT_TIME;
+
+      Serial.print("Subscribe ");
+      Serial.println(SubscribeTopic.c_str());
+      MqttClient.subscribe(SubscribeTopic.c_str());
+    }
+  } else {
+    digitalWrite(LED_BUILTIN, HIGH);
+
+    JsonDoc.clear();
+    if (measure(JsonDoc)) {
+      send(JsonDoc);
+    }
+
+    digitalWrite(LED_BUILTIN, LOW);
+
+    const auto start = millis();
+    while (millis() - start < static_cast<uint32_t>(INTERVAL)) {
+      WioCellular.doWork(10);  // Spin
+
+      MqttClient.loop();
+      if (!MqttClient.connected()) break;
     }
   }
-  mqttClient.loop();
+}
+
+static bool measure(JsonDocument& doc) {
+  Serial.println("### Measuring");
+
+  doc["uptime"] = millis() / 1000;
+
+  Serial.println("### Completed");
+
+  return true;
+}
+
+static bool send(const JsonDocument& doc) {
+  Serial.println("### Sending");
+
+  Serial.println("Publish");
+  std::string str;
+  serializeJson(JsonDoc, str);
+  Serial.printf(" Topic:   %s\n", PublishTopic.c_str());
+  Serial.printf(" Message: %s\n", str.c_str());
+  if (!MqttClient.publish(PublishTopic.c_str(), str.c_str())) {
+    Serial.println("ERROR: Failed to publish");
+    return false;
+  }
+
+  Serial.println("### Completed");
+
+  return true;
+}
+
+static void MqttClientCallback(char* topic, byte* payload, unsigned int length) {
+  char payloadStr[length + 1];
+  memcpy(payloadStr, payload, length);
+  payloadStr[length] = '\0';
+
+  Serial.println("Message arrived");
+  Serial.printf(" Topic:   %s\n", topic);
+  Serial.printf(" Message: %s\n", payloadStr);
 }

--- a/examples/cellular/cellular-mqtt-pubsubclient/cellular-mqtt-pubsubclient.ino
+++ b/examples/cellular/cellular-mqtt-pubsubclient/cellular-mqtt-pubsubclient.ino
@@ -25,7 +25,7 @@ static constexpr int POWER_ON_TIMEOUT = 1000 * 20;  // [ms]
 
 static constexpr int PDP_CONTEXT_ID = 1;
 static constexpr int SOCKET_ID = 0;
-static WioCellularTcpClient<WioCellularModule> TcpClient{ WioCellular, PDP_CONTEXT_ID, SOCKET_ID };
+static WioCellularArduinoTcpClient<WioCellularModule> TcpClient{ WioCellular, PDP_CONTEXT_ID };
 
 #define ENDPOINT "beam.soracom.io"
 #define PORT (1883)
@@ -39,7 +39,7 @@ void callback(char* topic, byte* payload, unsigned int length) {
   Serial.println("] ");
 
   String payload_str = "";
-  for (int i = 0; i < length; i++) {  // Parse Message
+  for (unsigned int i = 0; i < length; i++) {  // Parse Message
     payload_str += (char)payload[i];
   }
   Serial.println(payload_str);

--- a/examples/cellular/cellular-mqtt-pubsubclient/cellular-mqtt-pubsubclient.ino
+++ b/examples/cellular/cellular-mqtt-pubsubclient/cellular-mqtt-pubsubclient.ino
@@ -1,12 +1,12 @@
 /*
- * soracom-connectivity-pubsubclient.ino
+ * cellular-mqtt-pubsubclient.ino
  * Copyright (C) Seeed K.K.
  * MIT License
  */
 
 ////////////////////////////////////////////////////////////////////////////////
 // Libraries:
-//   http://librarymanager#PubSubClient 2.8
+//   http://librarymanager#PubSubClient 2.8.0
 
 #include <Adafruit_TinyUSB.h>
 #include <WioCellular.h>

--- a/examples/cellular/cellular-mqtt-pubsubclient/platformio.ini
+++ b/examples/cellular/cellular-mqtt-pubsubclient/platformio.ini
@@ -1,0 +1,19 @@
+[platformio]
+src_dir = .
+
+[env:seeed_wio_bg770a]
+platform = https://github.com/SeeedJP/platform-nordicnrf52
+platform_packages =
+    framework-arduinoadafruitnrf52 @ https://github.com/SeeedJP/Adafruit_nRF52_Arduino.git
+framework = arduino
+board = seeed_wio_bg770a
+build_flags =
+    -DBOARD_VERSION_1_0 ; Board version 1.0
+    -DCFG_LOGGER=3      ; 3:None, 2:Segger RTT, 1:Serial1, 0:Serial
+    ;-D ENABLE_TRACE    ; Enable trace
+    ;-O0                ; No optimization
+lib_archive = no ; https://github.com/platformio/platform-nordicnrf52/issues/119
+lib_deps =
+    seeedjp/WioCellular
+    bblanchon/ArduinoJson@^7.0.4
+    knolleary/PubSubClient@^2.8

--- a/examples/soracom/soracom-connectivity-pubsubclient/soracom-connectivity-pubsubclient.ino
+++ b/examples/soracom/soracom-connectivity-pubsubclient/soracom-connectivity-pubsubclient.ino
@@ -1,0 +1,93 @@
+/*
+ * soracom-connectivity-pubsubclient.ino
+ * Copyright (C) Seeed K.K.
+ * MIT License
+ */
+
+////////////////////////////////////////////////////////////////////////////////
+// Libraries:
+//   http://librarymanager#PubSubClient 2.8
+
+#include <Adafruit_TinyUSB.h>
+#include <WioCellular.h>
+#include <PubSubClient.h>
+
+#define SEARCH_ACCESS_TECHNOLOGY (WioCellularNetwork::SearchAccessTechnology::LTEM)
+#define LTEM_BAND (WioCellularNetwork::NTTDOCOMO_LTEM_BAND)
+static const char APN[] = "soracom.io";
+
+static constexpr int POWER_ON_TIMEOUT = 1000 * 20;  // [ms]
+
+#define ABORT_IF_FAILED(result) \
+  do { \
+    if ((result) != WioCellularResult::Ok) abort(); \
+  } while (0)
+
+static constexpr int PDP_CONTEXT_ID = 1;
+static constexpr int SOCKET_ID = 0;
+static WioCellularTcpClient<WioCellularModule> TcpClient{ WioCellular, PDP_CONTEXT_ID, SOCKET_ID };
+
+#define ENDPOINT "beam.soracom.io"
+#define PORT (1883)
+#define SUBSCRIBE_TOPIC "test/cmd"
+
+PubSubClient mqttClient(TcpClient);
+
+void callback(char* topic, byte* payload, unsigned int length) {
+  Serial.print("Message arrived [");
+  Serial.print(topic);                // Display topic
+  Serial.println("] ");
+
+  String payload_str = "";
+  for (int i = 0; i < length; i++) {  // Parse Message
+    payload_str += (char)payload[i];
+  }
+  Serial.println(payload_str);
+}
+
+void connectToMQTTS() {
+  Serial.print("Connecting to MQTTS broker via SORACOM Beam(Proxy): ");
+  mqttClient.setServer(ENDPOINT, PORT);
+  mqttClient.setCallback(callback);
+  mqttClient.connect(SUBSCRIBE_TOPIC);
+  mqttClient.subscribe(SUBSCRIBE_TOPIC, 0);
+  Serial.println("Connected!");
+}
+
+void setup(void) {
+  Serial.begin(115200);
+  {
+    const auto start = millis();
+    while (!Serial && millis() - start < 5000) {
+      delay(2);
+    }
+  }
+  Serial.println();
+  Serial.println();
+
+  Serial.println("Startup");
+  digitalWrite(LED_BUILTIN, HIGH);
+
+  WioCellular.begin();
+  ABORT_IF_FAILED(WioCellular.powerOn(POWER_ON_TIMEOUT));
+
+  WioNetwork.config.searchAccessTechnology = SEARCH_ACCESS_TECHNOLOGY;
+  WioNetwork.config.ltemBand = LTEM_BAND;
+  WioNetwork.config.apn = APN;
+  WioNetwork.begin();
+
+  connectToMQTTS();
+
+  digitalWrite(LED_BUILTIN, LOW);
+}
+
+void loop(void) {
+  if (!mqttClient.connected()) {
+    if (mqttClient.connect(SUBSCRIBE_TOPIC)) {
+      Serial.println("Connected");
+      mqttClient.subscribe(SUBSCRIBE_TOPIC, 0);
+      Serial.println("Subscribed");
+    }
+  }
+  mqttClient.loop();
+}


### PR DESCRIPTION
SORACOM Beamにpubsub clientを使用し、MQTTでSubscribeするサンプルを用意しました。
実装はhttp clientを使ったサンプルと、pubsub clientのサンプルを参考にしています。