### PR TITLE
Add PSM status log to soracom-uptime-psm example

### DIFF
--- a/examples/soracom/soracom-uptime-psm/soracom-uptime-psm.ino
+++ b/examples/soracom/soracom-uptime-psm/soracom-uptime-psm.ino
@@ -107,9 +107,11 @@ void loop() {
     }
   }
   if (!powerDown) {
+    Serial.println("PSM failed, powering off");
     WioNetwork.end();
     if (WioCellular.powerOff() != WioCellularResult::Ok) abort();
   } else {
+    Serial.println("PSM entered");
     WioNetwork.end(false);
   }
 


### PR DESCRIPTION
## Summary
- soracom-uptime-psm スケッチにPSM突入の成否をシリアルモニタで確認できるログ出力を追加
- PSM成功時: `PSM entered`、失敗時: `PSM failed, powering off` を表示

## Test plan
- [x] soracom-uptime-psm スケッチをビルド・書き込み
- [x] シリアルモニタでPSM成功時に `PSM entered` が表示されることを確認
- [ ] PSM失敗時に `PSM failed, powering off` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)